### PR TITLE
修改Demo案例中的支付回调方法， 同时对支付回调校验签名算法做了修改

### DIFF
--- a/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
+++ b/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
@@ -118,9 +118,6 @@ public class DemoController {
 //        } catch (Exception e) {
 //            return LantuPayConstant.FAIL;
 //        }
-//    bcf6973e02570312e14b3a4cabbd16ed
-    @Value("${ltzf.wx.secret-key}")
-    private String ltSecretKey;
 
     /**
      * 支付回调

--- a/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
+++ b/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
@@ -13,16 +13,13 @@ import cn.ltzf.sdkjava.constant.LantuPayConstant;
 import com.alibaba.fastjson.JSON;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
+++ b/lantu-sdk-demo/src/main/java/com/ltzf/sdkjava/demo/controller/DemoController.java
@@ -1,5 +1,4 @@
 package com.ltzf.sdkjava.demo.controller;
-import cn.hutool.core.net.URLDecoder;
 import cn.ltzf.sdkjava.api.LantuWxPayService;
 import cn.ltzf.sdkjava.bean.request.LantuWxPayGetWechatOpenIdRequest;
 import cn.ltzf.sdkjava.bean.request.LantuWxPayNativeOrderRequest;
@@ -21,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -95,29 +96,6 @@ public class DemoController {
         result.put("url", wechatOpenIdAuthorizeUrl);
         return result;
     }
-    
-    /**
-     * 测试蓝兔支付 接收订单的支付回调
-     *
-     * @return
-     */
-//    @GetMapping("/notify")
-//    public String notify(Map<String, String> params) {
-//        try {
-//            if (params == null || params.isEmpty()) {
-//                return LantuPayConstant.FAIL;
-//            }
-//            // 将参数转换为JSON
-//            String json = JSON.toJSONString(params);
-//            log.info("支付回调接口接收到参数:{}", json);
-//            LantuWxPayNotifyOrderResult result = this.lantuWxPayService.parseOrderNotifyResult(json);
-//            // 计算签名信息
-//            log.info("蓝兔微信支付异步通知请求解析后的对象：{}", result);
-//            // 模拟业务进行处理
-//            return LantuPayConstant.SUCCESS;
-//        } catch (Exception e) {
-//            return LantuPayConstant.FAIL;
-//        }
 
     /**
      * 支付回调
@@ -126,8 +104,6 @@ public class DemoController {
      */
     @PostMapping("/notify")
     public String notify(@RequestBody String requestBody){
-
-        System.out.println();
         log.info("requestBody： {}", requestBody);
         Map<String,String> params = new HashMap<String,String>();
         params = parseQueryString(requestBody);
@@ -152,14 +128,14 @@ public class DemoController {
      * @param query
      * @return
      */
-    private Map<String, String> parseQueryString(String query) {
-        return Arrays.stream(query.split("&"))
-                .map(param -> param.split("="))
-                .collect(Collectors.toMap(
-                        e -> URLDecoder.decode(e[0], StandardCharsets.UTF_8), // 解码键
-                        e -> e.length > 1 ? URLDecoder.decode(e[1], StandardCharsets.UTF_8) : "", // 解码值，如果存在
-                        (prev, next) -> next, // 如果有重复的键，使用最新的值
-                        LinkedHashMap::new)); // 保持插入顺序
+    private Map<String, String> parseQueryString(String query)  {
+       return Arrays.stream(query.split("&"))
+               .map(param -> param.split("="))
+               .collect(Collectors.toMap(
+                       e -> URLDecoder.decode(e[0]), // 解码键
+                       e -> e.length > 1 ? URLDecoder.decode(e[1]) : "", // 解码值，如果存在
+                       (prev, next) -> next, // 如果有重复的键，使用最新的值
+                           LinkedHashMap::new)); // 保持插入顺序
     }
 
 

--- a/lantu-sdk-demo/src/main/resources/application.yml
+++ b/lantu-sdk-demo/src/main/resources/application.yml
@@ -2,6 +2,6 @@ server:
   port: 9001
 ltzf:
   wx:
-    mch-id: "xxxx"
-    secret-key: "xxxx"
-    notify-url: "xxxxxxx"
+    mch-id:
+    secret-key:
+    notify-url: http://hm9mat.natappfree.cc/demo/notify

--- a/lantu-sdk-demo/src/main/resources/application.yml
+++ b/lantu-sdk-demo/src/main/resources/application.yml
@@ -4,4 +4,4 @@ ltzf:
   wx:
     mch-id:
     secret-key:
-    notify-url: http://hm9mat.natappfree.cc/demo/notify
+    notify-url:

--- a/lantu-sdk-java/pom.xml
+++ b/lantu-sdk-java/pom.xml
@@ -50,6 +50,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>cn.hutool</groupId>
+            <artifactId>hutool-all</artifactId>
+            <version>5.8.18</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/lantu-sdk-java/pom.xml
+++ b/lantu-sdk-java/pom.xml
@@ -50,12 +50,5 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>cn.hutool</groupId>
-            <artifactId>hutool-all</artifactId>
-            <version>5.8.18</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
-
 </project>

--- a/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/bean/result/LantuWxPayNotifyOrderResult.java
+++ b/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/bean/result/LantuWxPayNotifyOrderResult.java
@@ -68,6 +68,8 @@ public class LantuWxPayNotifyOrderResult {
         map.put("out_trade_no", outTradeNo);
         map.put("pay_no", payNo);
         map.put("total_fee", totalFee);
+        map.put("sign", sign);
+        // {"code":"0","timestamp":"1709172020","mch_id":"1667746679","order_no":"WX202402290959561957159999","out_trade_no":"20231709171995689","pay_no":"4200002108202402298072994957","total_fee":"0.01","sign":"0877AF7E4489DAB2F26F8C5D06084D7A","pay_channel":"wxpay","trade_type":"NATIVE","success_time":"2024-02-29 10:00:19","attach":"","openid":"o5wq46CadPI******woSlhxK7tz4"}
         boolean result = LantuWxPaySignUtil.checkSign(map, lantuWxPayService.getLantuWxConfigStorage().getSecretKey());
         if (!result) {
             throw new LantuPayErrorException("参数格式校验错误！");

--- a/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/bean/result/LantuWxPayNotifyOrderResult.java
+++ b/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/bean/result/LantuWxPayNotifyOrderResult.java
@@ -69,7 +69,6 @@ public class LantuWxPayNotifyOrderResult {
         map.put("pay_no", payNo);
         map.put("total_fee", totalFee);
         map.put("sign", sign);
-        // {"code":"0","timestamp":"1709172020","mch_id":"1667746679","order_no":"WX202402290959561957159999","out_trade_no":"20231709171995689","pay_no":"4200002108202402298072994957","total_fee":"0.01","sign":"0877AF7E4489DAB2F26F8C5D06084D7A","pay_channel":"wxpay","trade_type":"NATIVE","success_time":"2024-02-29 10:00:19","attach":"","openid":"o5wq46CadPI******woSlhxK7tz4"}
         boolean result = LantuWxPaySignUtil.checkSign(map, lantuWxPayService.getLantuWxConfigStorage().getSecretKey());
         if (!result) {
             throw new LantuPayErrorException("参数格式校验错误！");

--- a/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/util/LantuWxPaySignUtil.java
+++ b/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/util/LantuWxPaySignUtil.java
@@ -17,12 +17,12 @@ import java.util.TreeMap;
  * @date 2024-01-01 15:06:06
  */
 public class LantuWxPaySignUtil {
-    
+
     private static final List<String> NO_SIGN_PARAMS = Arrays.asList("sign");
-    
+
     private LantuWxPaySignUtil() {
     }
-    
+
     /**
      * 生成签名
      *
@@ -43,7 +43,7 @@ public class LantuWxPaySignUtil {
         }
         return createMapSign(map, signKey, ignoredParams);
     }
-    
+
     /**
      * 支付参数签名
      *
@@ -63,7 +63,7 @@ public class LantuWxPaySignUtil {
             if (StringUtils.isNotEmpty(value) && !ArrayUtils.contains(ignoredParams, key)) {
                 shouldSign = true;
             }
-        
+
             if (shouldSign) {
                 toSign.append(key).append("=").append(value).append("&");
             }
@@ -71,7 +71,7 @@ public class LantuWxPaySignUtil {
         toSign.append("key=").append(signKey);
         return DigestUtils.md5Hex(toSign.toString()).toUpperCase();
     }
-    
+
     /**
      * 校验签名是否正确.
      *
@@ -80,8 +80,13 @@ public class LantuWxPaySignUtil {
      * @return true - 签名校验成功，false - 签名校验失败
      */
     public static boolean checkSign(Map<String, String> params, String signKey) {
+        System.out.println("查看key: " + signKey);
+        System.out.println("查看sign: " + params.get("sign"));
+        String signUsed = params.get("sign");
         String sign = createMapSign(params, signKey, new String[0]);
-        return sign.equals(params.get("sign"));
+        String testSign = params.get("sign");
+        // 问题原因： 在进入createMapSign之后， 已经删除了sign。所以通过params.get("sign")肯定无法得到
+        System.out.println(testSign);
+        return sign.equals(signUsed);
     }
-    
 }

--- a/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/util/LantuWxPaySignUtil.java
+++ b/lantu-sdk-java/src/main/java/cn/ltzf/sdkjava/util/LantuWxPaySignUtil.java
@@ -80,13 +80,9 @@ public class LantuWxPaySignUtil {
      * @return true - 签名校验成功，false - 签名校验失败
      */
     public static boolean checkSign(Map<String, String> params, String signKey) {
-        System.out.println("查看key: " + signKey);
-        System.out.println("查看sign: " + params.get("sign"));
         String signUsed = params.get("sign");
         String sign = createMapSign(params, signKey, new String[0]);
-        String testSign = params.get("sign");
         // 问题原因： 在进入createMapSign之后， 已经删除了sign。所以通过params.get("sign")肯定无法得到
-        System.out.println(testSign);
         return sign.equals(signUsed);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
        
     </dependencyManagement>
     
-    <build>
+    <build>z
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
        
     </dependencyManagement>
     
-    <build>z
+    <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
##  1. 修改支付回调方法， 自定义了requestBody转map
#1 Bug: Demo案例中的支付回调应该是POST类型， 而不是get
 **测试结果**
![image](https://github.com/wuchubuzai2018/lantu-pay-sdk/assets/109897266/62d4b0ac-2b84-4981-b8f5-32ec06b5eab4)
显示可以接受参数

## 2. 修改校验签名中的逻辑错误
#2 Bug： 参数格式校验有问题。 具体应该是校验签名的问题
问题原因： 在进入createMapSign之后， 已经删除了sign。所以再次之后通过params.get("sign")肯定无法得到
**测试结果**
![image](https://github.com/wuchubuzai2018/lantu-pay-sdk/assets/109897266/cf953baf-894f-4a2b-a07a-e4defe9c081d)

